### PR TITLE
coerce string returned from string-downcase to runes:simple-rod

### DIFF
--- a/element.lisp
+++ b/element.lisp
@@ -301,9 +301,11 @@
                     (destructuring-bind (var name &optional (uri ""))
                        (if (and (listp entry) (cdr entry))
                             entry
-                            (list entry (string-downcase
-					 (princ-to-string
-					  (symbol-name entry)))))
+                            (list entry (coerce
+                                         (string-downcase
+					  (princ-to-string
+					   (symbol-name entry)))
+                                         'runes:simple-rod)))
                       `(,var (attribute-value ,element ,name ,uri))))
                   entries)
         ,@body)))

--- a/element.lisp
+++ b/element.lisp
@@ -301,14 +301,12 @@
                     (destructuring-bind (var name &optional (uri ""))
                        (if (and (listp entry) (cdr entry))
                             entry
-                            (list entry (coerce
-                                         (string-downcase
-					  (princ-to-string
-					   (symbol-name entry)))
-                                         'runes:simple-rod)))
+                            (list entry (coerce (string-downcase entry)
+                                                'runes:simple-rod)))
                       `(,var (attribute-value ,element ,name ,uri))))
                   entries)
         ,@body)))
+
 (defun list-attributes (element)
   "@arg[element]{an @class{element}}
    @return{a list of @class{attribute} nodes}


### PR DESCRIPTION
 * This relates to the issue discuseed here:
   <https://github.com/sharplispers/closure-common/pull/4>. If we
   don't change the runes:simple-rod type to admit simple-base-string
   then we run into a problem when we try to pass a simple-base-string
   on to CXML. So, if we're not gonig to change the type of
   simple-rod, we need to coerce the string returned from
   string-downcase to a simple-rod.